### PR TITLE
Fixing lag when filtering phenotype terms

### DIFF
--- a/src/phenotype2phenopacket/utils/phenopacket_utils.py
+++ b/src/phenotype2phenopacket/utils/phenopacket_utils.py
@@ -222,6 +222,7 @@ class SyntheticPatientGenerator:
                     if len(self.filtered_df) >= max_number:
                         break
                     self.check_frequency(phenotype_entry)
+            return pl.from_dicts(self.filtered_df)
         except TimeoutError:
             if len(self.filtered_df) == 0:
                 return frequency_df.sample(n=max_number)


### PR DESCRIPTION
Adding handling for a time limit when filtering phenotype terms dependent on frequency