### PR TITLE
33 use genes to disease from hpo in place of disease pg

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ p2p create --phenotype-annotation /path/to/phenotype.hpoa --output-dir /path/to/
 To add known gene-to-phenotype relationships to phenopackets:
 
 ```shell
-p2p add-genes --phenopacket-dir /path/to/synthetic-phenopackets --disease-pg /path/to/disease.pg --hgnc-data /path/to/hgnc_complete_set.txt --output-dir /path/to/output-dir
+p2p add-genes --phenopacket-dir /path/to/synthetic-phenopackets --genes-to-disease /path/to/genes_to_disease.txt --hgnc-data /path/to/hgnc_complete_set.txt --output-dir /path/to/output-dir
 ```
 
-> **_NOTE:_** To add known gene-to-phenotype the Exomiser disease.pg file is expected
+> **_NOTE:_** To add known gene-to-phenotype the genes_to_disease.txt is expected. It can be downloaded [here](https://hpo.jax.org/data/annotations).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "phenotype2phenopacket"
-version = "0.5.1"
+version = "0.6.0"
 description = ""
 authors = ["Yasemin Bridges <y.bridges@qmul.ac.uk>"]
 readme = "README.md"

--- a/src/phenotype2phenopacket/add/add_genes.py
+++ b/src/phenotype2phenopacket/add/add_genes.py
@@ -18,24 +18,24 @@ from phenotype2phenopacket.utils.phenopacket_utils import (
 
 
 def get_phenotype_to_disease_entries(
-    omim_disease_pg: pl.DataFrame, disease: Disease
+    genes_to_disease: pl.DataFrame, disease: Disease
 ) -> pl.DataFrame:
     """
     Return disease.pg entries that match the provided OMIM disease ID.
 
     Args:
-        omim_disease_pg (pl.DataFrame): DataFrame containing disease.pg entries.
+        genes_to_disease (pl.DataFrame): DataFrame containing genes_to_disease.txt entries.
         disease (Disease): Disease object containing the OMIM disease ID.
 
     Returns:
         pl.DataFrame: Filtered DataFrame containing entries matching the OMIM disease ID.
     """
-    return omim_disease_pg.filter(pl.col("database_id") == disease.term.id)
+    return genes_to_disease.filter(pl.col("disease_id") == disease.term.id)
 
 
 def add_genes(
     phenopacket_path: Path,
-    disease_pg: pl.DataFrame,
+    genes_to_disease: pl.DataFrame,
     gene_identifier_updater: GeneIdentifierUpdater,
     output_dir: Path,
 ):
@@ -44,21 +44,21 @@ def add_genes(
 
     Args:
         phenopacket_path (Path): Path to the phenopacket file.
-        disease_pg (pl.DataFrame): DataFrame containing disease.pg entries.
+        genes_to_disease (pl.DataFrame): DataFrame containing genes_to_disease.txt entries.
         gene_identifier_updater (GeneIdentifierUpdater): Object for updating gene identifiers.
         output_dir (Path): Directory to write the updated phenopacket.
 
     """
     phenopacket = phenopacket_reader(phenopacket_path)
     disease = PhenopacketUtil(phenopacket).return_phenopacket_disease()
-    filtered_disease_pg = get_phenotype_to_disease_entries(disease_pg, disease)
-    if len(filtered_disease_pg) == 0:
+    filtered_genes_to_disease = get_phenotype_to_disease_entries(genes_to_disease, disease)
+    if len(filtered_genes_to_disease) == 0:
         print(f"No gene-to-phenotype matches: {disease.term.id}, {disease.term.label}")
     else:
         phenopacket_with_genes = PhenopacketInterpretationExtender(
             phenopacket
         ).add_gene_interpretation_to_phenopacket(
-            omim_disease_phenotype_gene_map=filtered_disease_pg,
+            omim_disease_phenotype_gene_map=filtered_genes_to_disease,
             gene_identifier_updater=gene_identifier_updater,
         )
         (
@@ -68,13 +68,13 @@ def add_genes(
         )
 
 
-def add_genes_to_directory(phenopacket_dir: Path, disease_pg: pl.DataFrame, output_dir: Path):
+def add_genes_to_directory(phenopacket_dir: Path, genes_to_disease: pl.DataFrame, output_dir: Path):
     """
     Add known gene-to-phenotype relationships to the interpretations of a directory of phenopackets.
 
     Args:
         phenopacket_dir (Path): Directory containing the phenopacket files.
-        disease_pg (pl.DataFrame): DataFrame containing disease.pg entries.
+        genes_to_disease (pl.DataFrame): DataFrame containing genes_to_disease.txt entries.
         output_dir (Path): Directory to store the updated phenopackets.
     """
     hgnc_dict = create_hgnc_dict()
@@ -83,4 +83,4 @@ def add_genes_to_directory(phenopacket_dir: Path, disease_pg: pl.DataFrame, outp
         gene_identifier="ensembl_id", hgnc_data=hgnc_dict, identifier_map=identifier_map
     )
     for phenopacket_path in all_files(phenopacket_dir):
-        add_genes(phenopacket_path, disease_pg, gene_identifier_updater, output_dir)
+        add_genes(phenopacket_path, genes_to_disease, gene_identifier_updater, output_dir)

--- a/src/phenotype2phenopacket/cli_add.py
+++ b/src/phenotype2phenopacket/cli_add.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import click
 
 from phenotype2phenopacket.add.add_genes import add_genes_to_directory
-from phenotype2phenopacket.utils.utils import read_disease_pg
+from phenotype2phenopacket.utils.utils import read_genes_to_disease
 
 
 @click.command("add-genes")
@@ -15,10 +15,10 @@ from phenotype2phenopacket.utils.utils import read_disease_pg
     type=Path,
 )
 @click.option(
-    "--disease-pg",
-    "-d",
+    "--genes-to-disease",
+    "-g",
     required=True,
-    help="Path to disease.pg data file.",
+    help="Path to genes_to_disease.txt data file.",
     type=Path,
 )
 @click.option(
@@ -30,7 +30,7 @@ from phenotype2phenopacket.utils.utils import read_disease_pg
 )
 def add_genes_command(
     phenopacket_dir: Path,
-    disease_pg: Path,
+    genes_to_disease: Path,
     output_dir: Path,
 ):
     """
@@ -38,13 +38,13 @@ def add_genes_command(
 
     Args:
         phenopacket_dir (Path): Directory containing the phenopacket files.
-        disease_pg (Path): Path to the disease.pg file.
+        genes_to_disease (Path): Path to the genes_to_disease.txt file.
         output_dir (Path): Directory to store the updated phenopackets.
     """
     output_dir.mkdir(exist_ok=True)
-    disease_pg_df = read_disease_pg(disease_pg)
+    genes_to_disease_df = read_genes_to_disease(genes_to_disease)
     add_genes_to_directory(
         phenopacket_dir,
-        disease_pg_df,
+        genes_to_disease_df,
         output_dir,
     )

--- a/src/phenotype2phenopacket/utils/utils.py
+++ b/src/phenotype2phenopacket/utils/utils.py
@@ -184,10 +184,10 @@ def read_omim_id_list(omim_id_list_file_path: Path) -> List[str]:
 
 
 def filter_diseases(
-        num_disease: int,
-        omim_id: str,
-        omim_id_list: Path,
-        phenotype_annotation_data: PhenotypeAnnotation,
+    num_disease: int,
+    omim_id: str,
+    omim_id_list: Path,
+    phenotype_annotation_data: PhenotypeAnnotation,
 ) -> List[pl.DataFrame]:
     """
     Filter the phenotype annotation data to either only a specific disease, a specific number of diseases,

--- a/src/phenotype2phenopacket/utils/utils.py
+++ b/src/phenotype2phenopacket/utils/utils.py
@@ -39,37 +39,6 @@ def read_genes_to_disease(genes_to_disease: Path) -> pl.DataFrame:
     return pl.read_csv(genes_to_disease, sep="\t")
 
 
-# def read_disease_pg(disease_pg: Path) -> pl.DataFrame:
-#     """
-#     Read a disease.pg file and return a filtered Polars DataFrame.
-#
-#     This function reads the contents of a 'disease.pg' file using Polars read_csv method
-#     and constructs a DataFrame. It filters the DataFrame to include only rows where the 'database_id'
-#     column starts with 'OMIM'.
-#
-#     Args:
-#         disease_pg (Path): The path to the 'disease.pg' file.
-#
-#     Returns:
-#         pl.DataFrame: A filtered Polars DataFrame containing specific columns and rows
-#                       where 'database_id' starts with 'OMIM'.
-#     """
-#     disease = pl.read_csv(
-#         disease_pg,
-#         separator="|",
-#         new_columns=[
-#             "database_id",
-#             "gene_mim_number",
-#             "disease_name",
-#             "entrez_id",
-#             "diagnosis_status",
-#             "inheritance",
-#         ],
-#         has_header=False,
-#     )
-#     return disease.filter(pl.col("database_id").str.starts_with("OMIM"))
-
-
 def load_ontology(local_cached_ontology: Path = None):
     """
     Load the Human Phenotype Ontology (HPO).
@@ -215,10 +184,10 @@ def read_omim_id_list(omim_id_list_file_path: Path) -> List[str]:
 
 
 def filter_diseases(
-    num_disease: int,
-    omim_id: str,
-    omim_id_list: Path,
-    phenotype_annotation_data: PhenotypeAnnotation,
+        num_disease: int,
+        omim_id: str,
+        omim_id_list: Path,
+        phenotype_annotation_data: PhenotypeAnnotation,
 ) -> List[pl.DataFrame]:
     """
     Filter the phenotype annotation data to either only a specific disease, a specific number of diseases,

--- a/src/phenotype2phenopacket/utils/utils.py
+++ b/src/phenotype2phenopacket/utils/utils.py
@@ -28,35 +28,46 @@ def is_float(element: any) -> bool:
         return False
 
 
-def read_disease_pg(disease_pg: Path) -> pl.DataFrame:
+def read_genes_to_disease(genes_to_disease: Path) -> pl.DataFrame:
     """
-    Read a disease.pg file and return a filtered Polars DataFrame.
-
-    This function reads the contents of a 'disease.pg' file using Polars read_csv method
-    and constructs a DataFrame. It filters the DataFrame to include only rows where the 'database_id'
-    column starts with 'OMIM'.
-
+    Read the genes_to_disease.txt file and return a Polars DataFrame.
     Args:
-        disease_pg (Path): The path to the 'disease.pg' file.
-
+        genes_to_disease (Path): Path to the genes_to_disease.txt file.
     Returns:
-        pl.DataFrame: A filtered Polars DataFrame containing specific columns and rows
-                      where 'database_id' starts with 'OMIM'.
+        pl.DataFrame: A  Polars DataFrame containing the contents of the genes_to_disease.txt.
     """
-    disease = pl.read_csv(
-        disease_pg,
-        separator="|",
-        new_columns=[
-            "database_id",
-            "gene_mim_number",
-            "disease_name",
-            "entrez_id",
-            "diagnosis_status",
-            "inheritance",
-        ],
-        has_header=False,
-    )
-    return disease.filter(pl.col("database_id").str.starts_with("OMIM"))
+    return pl.read_csv(genes_to_disease, sep="\t")
+
+
+# def read_disease_pg(disease_pg: Path) -> pl.DataFrame:
+#     """
+#     Read a disease.pg file and return a filtered Polars DataFrame.
+#
+#     This function reads the contents of a 'disease.pg' file using Polars read_csv method
+#     and constructs a DataFrame. It filters the DataFrame to include only rows where the 'database_id'
+#     column starts with 'OMIM'.
+#
+#     Args:
+#         disease_pg (Path): The path to the 'disease.pg' file.
+#
+#     Returns:
+#         pl.DataFrame: A filtered Polars DataFrame containing specific columns and rows
+#                       where 'database_id' starts with 'OMIM'.
+#     """
+#     disease = pl.read_csv(
+#         disease_pg,
+#         separator="|",
+#         new_columns=[
+#             "database_id",
+#             "gene_mim_number",
+#             "disease_name",
+#             "entrez_id",
+#             "diagnosis_status",
+#             "inheritance",
+#         ],
+#         has_header=False,
+#     )
+#     return disease.filter(pl.col("database_id").str.starts_with("OMIM"))
 
 
 def load_ontology(local_cached_ontology: Path = None):

--- a/tests/test_phenopacket_utils.py
+++ b/tests/test_phenopacket_utils.py
@@ -202,21 +202,11 @@ disease_df_with_frequency = pl.from_dicts(
 
 gene_to_phenotypes = pl.from_dicts(
     [
+        {"disease_id": "OMIM:612567", "ncbi_gene_id": "NCBIGene:3588", "gene_symbol": "IL10RB"},
         {
-            "database_id": "OMIM:612567",
-            "gene_mim_number": "OMIM:123889",
-            "disease_name": "Inflammatory bowel disease 25, early onset, autosomal recessive",
-            "entrez_id": "3588",
-            "diagnosis_status": "D",
-            "inheritance": "R",
-        },
-        {
-            "database_id": "OMIM:612567",
-            "gene_mim_number": "OMIM:123889",
-            "disease_name": "Inflammatory bowel disease 25, early onset, autosomal recessive",
-            "entrez_id": "1",
-            "diagnosis_status": "D",
-            "inheritance": "R",
+            "disease_id": "OMIM:612567",
+            "ncbi_gene_id": "NCBIGene:1",
+            "gene_symbol": "ADA",
         },
     ]
 )
@@ -1179,12 +1169,9 @@ class TestPhenopacketInterpretationExtender(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.phenopacket = PhenopacketInterpretationExtender(phenopacket)
         cls.phenotype_to_gene_entry = {
-            "database_id": "OMIM:612567",
-            "gene_mim_number": "OMIM:123889",
-            "disease_name": "Inflammatory bowel disease 25, early onset, autosomal recessive",
-            "entrez_id": "3588",
-            "diagnosis_status": "D",
-            "inheritance": "R",
+            "disease_id": "OMIM:612567",
+            "ncbi_gene_id": "NCBIGene:3588",
+            "gene_symbol": "IL10RB",
         }
         cls.gene_identifier_updater = GeneIdentifierUpdater(
             gene_identifier="ensembl_id",
@@ -1224,7 +1211,7 @@ class TestPhenopacketInterpretationExtender(unittest.TestCase):
                 GenomicInterpretation(
                     subject_or_biosample_id="patient1",
                     interpretation_status=4,
-                    gene=GeneDescriptor(value_id="ENSG00000121410", symbol="A1BG"),
+                    gene=GeneDescriptor(value_id="ENSG00000196839", symbol="ADA"),
                 ),
             ],
         )
@@ -1258,7 +1245,7 @@ class TestPhenopacketInterpretationExtender(unittest.TestCase):
                     GenomicInterpretation(
                         subject_or_biosample_id="patient1",
                         interpretation_status=4,
-                        gene=GeneDescriptor(value_id="ENSG00000121410", symbol="A1BG"),
+                        gene=GeneDescriptor(value_id="ENSG00000196839", symbol="ADA"),
                     ),
                 ],
             ),
@@ -1290,7 +1277,7 @@ class TestPhenopacketInterpretationExtender(unittest.TestCase):
                         GenomicInterpretation(
                             subject_or_biosample_id="patient1",
                             interpretation_status=4,
-                            gene=GeneDescriptor(value_id="ENSG00000121410", symbol="A1BG"),
+                            gene=GeneDescriptor(value_id="ENSG00000196839", symbol="ADA"),
                         ),
                     ],
                 ),


### PR DESCRIPTION
Refactor to use `genes_to_disease.txt` instead of the `disease.pg` from the Exomiser db. The `genes_to_disease.txt` is more accessible and can be downloaded from [here](https://hpo.jax.org/data/annotations)