### PR TITLE
Create phenopackets without phenotypic features

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ To convert all OMIM diseases in a phenotype annotation file to disease phenopack
 p2p convert --phenotype-annotation /path/to/phenotype.hpoa --output-dir /path/to/output-dir
 ```
 
+To convert all OMIM diseases in a phenotype annotation file to lightweight disease phenopackets (without phenotypic features):
+```shell
+p2p convert --phenotype-annotation /path/to/phenotype.hpoa --output-dir /path/to/output-dir --skip-phenotypic-features
+```
+
 To create synthetic patient disease phenopackets, where the dataset is more variable and frequencies are taken
 into account and constrained noise is applied :
 

--- a/src/phenotype2phenopacket/cli_convert.py
+++ b/src/phenotype2phenopacket/cli_convert.py
@@ -63,6 +63,15 @@ from phenotype2phenopacket.convert.convert import convert_to_phenopackets
     default=None,
     type=Path,
 )
+@click.option(
+    "--skip-phenotypic-features",
+    "-s",
+    is_flag=True,
+    default=False,
+    required=False,
+    help="Boolean flag to skip writing phenotypic features to phenopacket.",
+)
+
 def convert_to_phenopackets_command(
     phenotype_annotation: Path,
     num_disease: int,
@@ -70,6 +79,7 @@ def convert_to_phenopackets_command(
     omim_id_list: Path,
     output_dir: Path,
     local_ontology_cache: Path,
+    skip_phenotypic_features: bool,
 ):
     """
     Convert a phenotype annotation file to a set of disease phenopackets.
@@ -84,5 +94,5 @@ def convert_to_phenopackets_command(
     """
     output_dir.mkdir(exist_ok=True)
     convert_to_phenopackets(
-        phenotype_annotation, num_disease, omim_id, omim_id_list, output_dir, local_ontology_cache
+        phenotype_annotation, num_disease, omim_id, omim_id_list, output_dir, local_ontology_cache, skip_phenotypic_features
     )

--- a/src/phenotype2phenopacket/cli_convert.py
+++ b/src/phenotype2phenopacket/cli_convert.py
@@ -71,7 +71,6 @@ from phenotype2phenopacket.convert.convert import convert_to_phenopackets
     required=False,
     help="Boolean flag to skip writing phenotypic features to phenopacket.",
 )
-
 def convert_to_phenopackets_command(
     phenotype_annotation: Path,
     num_disease: int,
@@ -94,5 +93,11 @@ def convert_to_phenopackets_command(
     """
     output_dir.mkdir(exist_ok=True)
     convert_to_phenopackets(
-        phenotype_annotation, num_disease, omim_id, omim_id_list, output_dir, local_ontology_cache, skip_phenotypic_features
+        phenotype_annotation,
+        num_disease,
+        omim_id,
+        omim_id_list,
+        output_dir,
+        local_ontology_cache,
+        skip_phenotypic_features,
     )

--- a/src/phenotype2phenopacket/convert/convert.py
+++ b/src/phenotype2phenopacket/convert/convert.py
@@ -19,7 +19,7 @@ def convert_to_phenopackets(
     omim_id_list: Path,
     output_dir: Path,
     local_cached_ontology: Path,
-    skip_phenotypic_features: bool
+    skip_phenotypic_features: bool,
 ):
     """
     Convert a phenotype annotation file to a set of disease-specific phenopackets.
@@ -48,7 +48,9 @@ def convert_to_phenopackets(
             continue
         phenopacket_file = PhenotypeAnnotationToPhenopacketConverter(
             human_phenotype_ontology
-        ).create_phenopacket(omim_disease, phenotype_annotation_data.version, None, skip_phenotypic_features)
+        ).create_phenopacket(
+            omim_disease, phenotype_annotation_data.version, None, skip_phenotypic_features
+        )
         write_phenopacket(
             phenopacket_file.phenopacket, output_dir.joinpath(phenopacket_file.phenopacket_path)
         )

--- a/src/phenotype2phenopacket/convert/convert.py
+++ b/src/phenotype2phenopacket/convert/convert.py
@@ -19,6 +19,7 @@ def convert_to_phenopackets(
     omim_id_list: Path,
     output_dir: Path,
     local_cached_ontology: Path,
+    skip_phenotypic_features: bool
 ):
     """
     Convert a phenotype annotation file to a set of disease-specific phenopackets.
@@ -47,7 +48,7 @@ def convert_to_phenopackets(
             continue
         phenopacket_file = PhenotypeAnnotationToPhenopacketConverter(
             human_phenotype_ontology
-        ).create_phenopacket(omim_disease, phenotype_annotation_data.version, None)
+        ).create_phenopacket(omim_disease, phenotype_annotation_data.version, None, skip_phenotypic_features)
         write_phenopacket(
             phenopacket_file.phenopacket, output_dir.joinpath(phenopacket_file.phenopacket_path)
         )

--- a/src/phenotype2phenopacket/utils/phenopacket_utils.py
+++ b/src/phenotype2phenopacket/utils/phenopacket_utils.py
@@ -835,6 +835,7 @@ class PhenotypeAnnotationToPhenopacketConverter:
         omim_disease_df: pl.DataFrame,
         hpoa_version: str,
         pt_id: str,
+        skip_phenotypic_features: bool,
         onset: OnsetTerm = None,
     ) -> PhenopacketFile:
         """
@@ -853,7 +854,7 @@ class PhenotypeAnnotationToPhenopacketConverter:
             PhenopacketFile: A class instance containing the phenopacket file name and
             the generated Phenopacket.
         """
-        phenotypic_features = self.create_phenotypic_features(omim_disease_df)
+        phenotypic_features = [] if skip_phenotypic_features else self.create_phenotypic_features(omim_disease_df) 
         phenotype_annotation_entry = omim_disease_df.to_dicts()[0]
         return PhenopacketFile(
             phenopacket=Phenopacket(

--- a/src/phenotype2phenopacket/utils/phenopacket_utils.py
+++ b/src/phenotype2phenopacket/utils/phenopacket_utils.py
@@ -854,7 +854,9 @@ class PhenotypeAnnotationToPhenopacketConverter:
             PhenopacketFile: A class instance containing the phenopacket file name and
             the generated Phenopacket.
         """
-        phenotypic_features = [] if skip_phenotypic_features else self.create_phenotypic_features(omim_disease_df) 
+        phenotypic_features = (
+            [] if skip_phenotypic_features else self.create_phenotypic_features(omim_disease_df)
+        )
         phenotype_annotation_entry = omim_disease_df.to_dicts()[0]
         return PhenopacketFile(
             phenopacket=Phenopacket(


### PR DESCRIPTION
## Summary
Adds the possibility of creating disease phenopackets without phenotypic features. 

## Rationale
This is particularly useful for benchmarking the PhenoDigm pipeline used in IMPC; it reduces the size of the phenopackets considering the phenotypic features of each disease are not needed for this purpose. This could be useful for other users. 

## Usage
This feature adds a new flag  to `convert`: `--skip-phenotypic-features`. When used, phenotypic features are not added to the phenopackets. 